### PR TITLE
fix: 3 处 agent 感知-决策-执行链路不一致

### DIFF
--- a/agents/novel-agent.md
+++ b/agents/novel-agent.md
@@ -173,7 +173,7 @@ knowledge:
 
 - **Context Isolation:** 每次 OBSERVE 从文件系统重建状态，不依赖上一次运行的上下文缓存
 - **State Persistence:** `.agent/status.md` 是唯一持久状态
-- **Shared Context Keys:** `current_volume`、`current_chapter`、`phase`（setup/outline/draft/archive）
+- **Shared Context Keys:** `current_volume`、`current_chapter`、`phase`（setup/outline/draft/anti-ai/review/archive）
 
 ## 十、可观测性与调试
 

--- a/agents/reader.md
+++ b/agents/reader.md
@@ -25,8 +25,8 @@ knowledge:
     description: 检查是否仍有 AI 味
   - path: .claude/knowledge/chapter-quality-checklist.md
     description: 验收清单
-  - path: .claude/knowledge/genre-example.md
-    description: 本题材读者预期
+  - path: .claude/knowledge/genre-example/
+    description: 本题材读者预期（从 settings/genre-setting.md 确定题材后加载对应文件）
   - path: .claude/knowledge/scene-craft/index.md
     description: 场景写作方法论索引（维度 10 检查时对照注入的方法论）
   - path: .claude/knowledge/plot-craft/opening-hooks.md

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -60,7 +60,7 @@ knowledge:
 
   LOAD SKILL:
     加载 skills/writing-execution.md
-    执行全流程：Step 1(准备) → Step 2(清理上下文) → Step 3(写作) → Step 4(验证) → Step 5(保存快照)
+    执行全流程：Step 1(准备) → Step 2(清理上下文) → Step 3(写作) → Step 4(验证) → Step 5(叙事规则自查) → Step 6(保存快照)
 
   OBSERVE:
     读什么？← 三(Input Sources): write-order.md + prompt.md


### PR DESCRIPTION
## Summary
审计发现 3 处 agent 定义与实际情况不一致的问题。

## Changes
1. **novel-agent.md**: `shared_context_keys.phase` 补全 `anti-ai` 和 `review`（原值 `setup/outline/draft/archive` 已过期）
2. **writer.md**: Loop Integration 步骤数从 5 步改为 6 步，对齐 writing-execution.md（新增 Step 5 叙事规则自查）
3. **reader.md**: `.claude/knowledge/genre-example.md` 单文件路径改为目录路径（实际为目录结构）

## Verification
- 3 处均为 agent 内部引用/Pipeline 定义，不影响运行时，纯元数据修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)