### PR TITLE
fix: prompt-crafter 去掉 model 字段，不再绑定到 flash 模型

### DIFF
--- a/agents/prompt-crafter.md
+++ b/agents/prompt-crafter.md
@@ -3,7 +3,6 @@ name: prompt-crafter
 description: 根据章纲、动态记忆和知识库，组装 4 层提示词结构
 role: 提示词工程师
 react: true
-model: flash
 memory: []
 skills:
   - path: skills/prompt-crafting.md


### PR DESCRIPTION
## Summary
- prompt-crafter 子 agent 在模型调用上失败，去掉 `model: flash` 字段，改由默认模型处理